### PR TITLE
Add building color status

### DIFF
--- a/lib/ci_server_plugins/cctray_server_plugin.rb
+++ b/lib/ci_server_plugins/cctray_server_plugin.rb
@@ -8,7 +8,11 @@ module Blinky
       server Chicanery::Cctray.new 'blinky build', url, options
 
       when_run do |current_state|
-        current_state.has_failure? ? failure! : success!
+        if current_state.building?
+          building!
+        else
+          current_state.has_failure? ? failure! : success!
+        end               
       end
       
       begin


### PR DESCRIPTION
I needed more than just the basic green for all successful builds or red for one or more failed builds.  I wanted the light to change to a different color when a build was active within the cctray view being watched.   Therefore I simply hacked the file to look first if something was building then change it blue otherwise the same behavior as before.   Simple change that I think adds a new element to this.   Perhaps this could be extended further to be configurable but I'm just learning Ruby and didn't want to jump in for anything more difficult than this.
