### PR TITLE
Modify the blink(1) recipe to allow direct lookup of serial number

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,20 +1,24 @@
 PATH
   remote: .
   specs:
-    blinky (0.0.11)
+    blinky (0.0.12)
       chicanery (~> 0.1.0)
       libusb (~> 0.2.2)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    chicanery (0.1.0)
+    chicanery (0.1.8)
+      colorize (~> 0)
       nokogiri (~> 1)
+    colorize (0.7.3)
     diff-lcs (1.1.3)
-    ffi (1.3.1)
+    ffi (1.9.5)
     libusb (0.2.2)
       ffi (>= 1.0)
-    nokogiri (1.5.6)
+    mini_portile (0.6.0)
+    nokogiri (1.6.3.1)
+      mini_portile (= 0.6.0)
     rake (10.0.3)
     rspec (2.11.0)
       rspec-core (~> 2.11.0)

--- a/lib/blinky/light.rb
+++ b/lib/blinky/light.rb
@@ -1,8 +1,9 @@
 module Blinky
   class Light
 
-    def initialize device_handle, recipe, plugins
-      @handle = device_handle
+    def initialize device, recipe, plugins
+      @device = device
+      @handle = device.open
       self.extend(recipe)   
       plugins.each do |plugin|
         self.extend(plugin)

--- a/lib/blinky/light_factory.rb
+++ b/lib/blinky/light_factory.rb
@@ -8,7 +8,7 @@ module Blinky
         found_devices << device  
         matching_recipe = recipes[device.idVendor][device.idProduct] 
         if matching_recipe
-          lights << Light.new(device.open, matching_recipe, plugins)
+          lights << Light.new(device, matching_recipe, plugins)
         end
       end
       raise NoSupportedDevicesFound.new found_devices if lights.empty?

--- a/lib/blinky/version.rb
+++ b/lib/blinky/version.rb
@@ -1,3 +1,3 @@
 module Blinky
-  VERSION = "0.0.12"
+  VERSION = "0.0.12.1"
 end

--- a/lib/blinky/version.rb
+++ b/lib/blinky/version.rb
@@ -1,3 +1,3 @@
 module Blinky
-  VERSION = "0.0.12.1"
+  VERSION = "0.0.12"
 end

--- a/lib/device_recipes/thing_m/blink_1.rb
+++ b/lib/device_recipes/thing_m/blink_1.rb
@@ -3,65 +3,66 @@ module Blinky
     module Blink1
 
       def success!
-        stop 
-        set_colour("\x00\xFF\x00") 
+        stop
+        set_colour("\x00\xFF\x00")
       end
 
       def failure!
         stop
-        play   
+        play
       end
 
-      def building! 
-        stop 
-        set_colour("\x00\x00\xFF") 
+      def building!
+        stop
+        set_colour("\x00\x00\xFF")
       end
 
       def warning!
         stop
-        set_colour("\xFF\x2A\x00") 
+        set_colour("\xFF\x2A\x00")
       end
 
       def off!
         stop
-        set_colour("\x00\x00\x00") 
+        set_colour("\x00\x00\x00")
       end
 
       def init
-         set_flash_pattern("\xFF\x00\x00")  
+         set_flash_pattern("\xFF\x00\x00")
+      end
+
+      def serial_number
+        @device.serial_number
       end
 
       private
       def set_colour colour
         @handle.usb_control_msg(0x21, 0x09, (3 << 8) | 1, 0, "\x01\x6E#{colour}\x00\x00\x00\x00", 0)
       end
-      
+
       def play
          @handle.usb_control_msg(0x21, 0x09, (3 << 8) | 1, 0, "\x01p\x01\x01\x00\x00\x00\x00\x00", 0)
       end
-      
+
       def stop
-         @handle.usb_control_msg(0x21, 0x09, (3 << 8) | 1, 0, "\x01p\x00\x01\x00\x00\x00\x00\x00", 0) 
+         @handle.usb_control_msg(0x21, 0x09, (3 << 8) | 1, 0, "\x01p\x00\x01\x00\x00\x00\x00\x00", 0)
       end
-      
+
       def set_flash_pattern colour
         @handle.usb_control_msg(0x21, 0x09, (3 << 8) | 1, 0, "\x01P#{colour}\x00\x0A\x00\x00", 0)
         @handle.usb_control_msg(0x21, 0x09, (3 << 8) | 1, 0, "\x01P\x00\x00\x00\x00\x0A\x01\x00", 0)
         @handle.usb_control_msg(0x21, 0x09, (3 << 8) | 1, 0, "\x01P\x00\x00\x00\x00\x00\x02\x00", 0)
-        @handle.usb_control_msg(0x21, 0x09, (3 << 8) | 1, 0, "\x01P\x00\x00\x00\x00\x00\x03\x00", 0) 
-        @handle.usb_control_msg(0x21, 0x09, (3 << 8) | 1, 0, "\x01P\x00\x00\x00\x00\x00\x04\x00", 0) 
-        @handle.usb_control_msg(0x21, 0x09, (3 << 8) | 1, 0, "\x01P\x00\x00\x00\x00\x00\x05\x00", 0) 
-        @handle.usb_control_msg(0x21, 0x09, (3 << 8) | 1, 0, "\x01P\x00\x00\x00\x00\x00\x06\x00", 0) 
-        @handle.usb_control_msg(0x21, 0x09, (3 << 8) | 1, 0, "\x01P\x00\x00\x00\x00\x00\x07\x00", 0) 
-        @handle.usb_control_msg(0x21, 0x09, (3 << 8) | 1, 0, "\x01P\x00\x00\x00\x00\x00\x08\x00", 0) 
-        @handle.usb_control_msg(0x21, 0x09, (3 << 8) | 1, 0, "\x01P\x00\x00\x00\x00\x00\x09\x00", 0) 
-        @handle.usb_control_msg(0x21, 0x09, (3 << 8) | 1, 0, "\x01P\x00\x00\x00\x00\x00\x0A\x00", 0) 
+        @handle.usb_control_msg(0x21, 0x09, (3 << 8) | 1, 0, "\x01P\x00\x00\x00\x00\x00\x03\x00", 0)
+        @handle.usb_control_msg(0x21, 0x09, (3 << 8) | 1, 0, "\x01P\x00\x00\x00\x00\x00\x04\x00", 0)
+        @handle.usb_control_msg(0x21, 0x09, (3 << 8) | 1, 0, "\x01P\x00\x00\x00\x00\x00\x05\x00", 0)
+        @handle.usb_control_msg(0x21, 0x09, (3 << 8) | 1, 0, "\x01P\x00\x00\x00\x00\x00\x06\x00", 0)
+        @handle.usb_control_msg(0x21, 0x09, (3 << 8) | 1, 0, "\x01P\x00\x00\x00\x00\x00\x07\x00", 0)
+        @handle.usb_control_msg(0x21, 0x09, (3 << 8) | 1, 0, "\x01P\x00\x00\x00\x00\x00\x08\x00", 0)
+        @handle.usb_control_msg(0x21, 0x09, (3 << 8) | 1, 0, "\x01P\x00\x00\x00\x00\x00\x09\x00", 0)
+        @handle.usb_control_msg(0x21, 0x09, (3 << 8) | 1, 0, "\x01P\x00\x00\x00\x00\x00\x0A\x00", 0)
         @handle.usb_control_msg(0x21, 0x09, (3 << 8) | 1, 0, "\x01P\x00\x00\x00\x00\x00\x0B\x00", 0)
       end
-      
-    end     
+
+    end
   end
 end
-
-
- 

--- a/spec/light_spec.rb
+++ b/spec/light_spec.rb
@@ -1,64 +1,69 @@
 require File.join(File.dirname(__FILE__), '/spec_helper')
 
-module Blinky 
+module Blinky
 
   module TestEngineering
-    module TestModel           
-      def success! 
+    module TestModel
+      def success!
         @handle.indicate_success
-      end   
-      
+      end
+
       def init
         @handle.init
       end
-            
+
     end
   end
 
-  module MockCiPlugin            
-    def watch_mock_ci_server 
+  module MockCiPlugin
+    def watch_mock_ci_server
       notify_build_status
-    end      
-  end  
+    end
+  end
 
-  module AnotherMockCiPlugin            
-    def watch_another_mock_ci_server 
+  module AnotherMockCiPlugin
+    def watch_another_mock_ci_server
       notify_a_different_build_status
-    end      
+    end
   end
 
 
   describe "Light" do
- 
+
     it "will use device recipe to initialise itself on construction" do
-        supported_device = double("supported device",:idVendor => 0x2000, :idProduct => 0x2222) 
-        supported_device.should_receive(:init)
-        Light.new(supported_device, TestEngineering::TestModel, [MockCiPlugin, AnotherMockCiPlugin ] )
+      supported_device = double("supported device",:idVendor => 0x2000, :idProduct => 0x2222)
+      device_handle = double(:handle)
+      device_handle.stub(:init)
+      supported_device.should_receive(:open).and_return(device_handle)
+      Light.new(supported_device, TestEngineering::TestModel, [MockCiPlugin, AnotherMockCiPlugin ] )
     end
 
     describe "that has been constructed with a device, a device recipe, and some CI plugins" do
 
       before(:each) do
-        @supported_device = double("supported device",:idVendor => 0x2000, :idProduct => 0x2222) 
-        @supported_device.stub(:init)   
+        @supported_device = double("supported device", :idVendor => 0x2000, :idProduct => 0x2222)
+        @supported_device.stub(:init)
+        @device_handle = double(:handle)
+        @device_handle.stub(:init)
+        @supported_device.stub(:open).and_return(@device_handle)
         @light = Light.new(@supported_device, TestEngineering::TestModel, [MockCiPlugin, AnotherMockCiPlugin ] )
       end
 
-      it "can call recipe methods on the device" do
-        @supported_device.should_receive(:indicate_success)
-        @light.success!                  
+      it "can call recipe methods on the device handle" do
+        @device_handle.should_receive(:indicate_success)
+        @light.success!
       end
 
       it "can receive call back methods defined in a plugins" do
         @light.should_receive(:notify_build_status)
-        @light.watch_mock_ci_server 
+        @light.watch_mock_ci_server
       end
 
       it "can receive call backs from a server via another plugin" do
         @light.should_receive(:notify_a_different_build_status)
-        @light.watch_another_mock_ci_server                  
+        @light.watch_another_mock_ci_server
       end
 
-    end     
+    end
   end
 end


### PR DESCRIPTION
Handy for assigning a specific blink(1) to a specific task.
